### PR TITLE
NF-545 Generate correlation ID and send as header in request to BE

### DIFF
--- a/app/connectors/NDRCConnector.scala
+++ b/app/connectors/NDRCConnector.scala
@@ -31,14 +31,18 @@ class NDRCConnector @Inject() (config: Configuration, httpClient: HttpClient)(im
 
   private val baseUrl = config.get[Service]("microservice.services.national-duty-repayment-center")
 
-  def submitClaim(request: CreateClaimRequest, correlationId: String)(implicit hc: HeaderCarrier): Future[ClientClaimSuccessResponse] =
+  def submitClaim(request: CreateClaimRequest, correlationId: String)(implicit
+    hc: HeaderCarrier
+  ): Future[ClientClaimSuccessResponse] =
     httpClient.POST[CreateClaimRequest, ClientClaimSuccessResponse](
       s"$baseUrl/create-case",
       request,
       Seq("X-Correlation-Id" -> correlationId)
     )
 
-  def submitAmendClaim(request: AmendClaimRequest, correlationId: String)(implicit hc: HeaderCarrier): Future[ClientClaimSuccessResponse] =
+  def submitAmendClaim(request: AmendClaimRequest, correlationId: String)(implicit
+    hc: HeaderCarrier
+  ): Future[ClientClaimSuccessResponse] =
     httpClient.POST[AmendClaimRequest, ClientClaimSuccessResponse](
       s"$baseUrl/amend-case",
       request,

--- a/app/connectors/NDRCConnector.scala
+++ b/app/connectors/NDRCConnector.scala
@@ -31,10 +31,18 @@ class NDRCConnector @Inject() (config: Configuration, httpClient: HttpClient)(im
 
   private val baseUrl = config.get[Service]("microservice.services.national-duty-repayment-center")
 
-  def submitClaim(request: CreateClaimRequest)(implicit hc: HeaderCarrier): Future[ClientClaimSuccessResponse] =
-    httpClient.POST[CreateClaimRequest, ClientClaimSuccessResponse](s"$baseUrl/create-case", request)
+  def submitClaim(request: CreateClaimRequest, correlationId: String)(implicit hc: HeaderCarrier): Future[ClientClaimSuccessResponse] =
+    httpClient.POST[CreateClaimRequest, ClientClaimSuccessResponse](
+      s"$baseUrl/create-case",
+      request,
+      Seq("X-Correlation-Id" -> correlationId)
+    )
 
-  def submitAmendClaim(request: AmendClaimRequest)(implicit hc: HeaderCarrier): Future[ClientClaimSuccessResponse] =
-    httpClient.POST[AmendClaimRequest, ClientClaimSuccessResponse](s"$baseUrl/amend-case", request)
+  def submitAmendClaim(request: AmendClaimRequest, correlationId: String)(implicit hc: HeaderCarrier): Future[ClientClaimSuccessResponse] =
+    httpClient.POST[AmendClaimRequest, ClientClaimSuccessResponse](
+      s"$baseUrl/amend-case",
+      request,
+      Seq("X-Correlation-Id" -> correlationId)
+    )
 
 }

--- a/app/services/ClaimService.scala
+++ b/app/services/ClaimService.scala
@@ -28,7 +28,7 @@ import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 case class CaseAlreadyExists(msg: String) extends RuntimeException(msg)
 
-class ClaimService @Inject()(connector: NDRCConnector)(implicit ec: ExecutionContext) {
+class ClaimService @Inject() (connector: NDRCConnector)(implicit ec: ExecutionContext) {
 
   def submitClaim(userAnswers: UserAnswers)(implicit hc: HeaderCarrier, request: DataRequest[_]): Future[String] = {
     val maybeRegistrationRequest: Option[CreateClaimRequest] = CreateClaimRequest.buildValidClaimRequest(userAnswers)
@@ -82,7 +82,7 @@ class ClaimService @Inject()(connector: NDRCConnector)(implicit ec: ExecutionCon
     }
   }
 
-  private def correlationId (hc: HeaderCarrier): String = {
+  private def correlationId(hc: HeaderCarrier): String =
     hc.requestId.map(_.value).getOrElse(UUID.randomUUID().toString)
-  }
+
 }

--- a/test/connectors/NDRCConnectorSpec.scala
+++ b/test/connectors/NDRCConnectorSpec.scala
@@ -29,7 +29,6 @@ import uk.gov.hmrc.http.HeaderCarrier
 import utils.WireMockHelper
 import com.github.tomakehurst.wiremock.client.WireMock._
 import base.SpecBase
-import models.ClaimId
 import models.responses.{ClientClaimSuccessResponse, NDRCFileTransferResult}
 
 import java.time.LocalDateTime
@@ -66,7 +65,7 @@ class NDRCConnectorSpec extends SpecBase with WireMockHelper with MustMatchers {
             .willReturn(ok(responseBody))
         )
 
-        val result = connector.submitClaim(createClaimRequest).futureValue
+        val result = connector.submitClaim(createClaimRequest, "111").futureValue
 
         result mustEqual ClientClaimSuccessResponse(
           correlationId = "111",
@@ -85,7 +84,7 @@ class NDRCConnectorSpec extends SpecBase with WireMockHelper with MustMatchers {
 
         server.stubFor(post(urlEqualTo(url)).willReturn(notFound()))
 
-        val result = connector.submitClaim(createClaimRequest).value
+        val result = connector.submitClaim(createClaimRequest, "111").value
         result mustBe None
       }
     }
@@ -114,7 +113,7 @@ class NDRCConnectorSpec extends SpecBase with WireMockHelper with MustMatchers {
             .willReturn(ok(responseBody))
         )
 
-        val result = connector.submitAmendClaim(amendClaimRequest).futureValue
+        val result = connector.submitAmendClaim(amendClaimRequest, "111").futureValue
 
         result mustEqual ClientClaimSuccessResponse(
           correlationId = "111",
@@ -133,7 +132,7 @@ class NDRCConnectorSpec extends SpecBase with WireMockHelper with MustMatchers {
 
         server.stubFor(post(urlEqualTo(url)).willReturn(notFound()))
 
-        val result = connector.submitAmendClaim(amendClaimRequest).value
+        val result = connector.submitAmendClaim(amendClaimRequest, "111").value
         result mustBe None
       }
     }

--- a/test/service/ClaimServiceSpec.scala
+++ b/test/service/ClaimServiceSpec.scala
@@ -45,8 +45,8 @@ class ClaimServiceSpec extends SpecBase with MustMatchers with ScalaCheckPropert
       implicit val request: Request[_] = FakeRequest().withSession(SessionKeys.authToken -> "Bearer XYZ")
       val dataRequest                  = DataRequest(request, "12", testUserAnswers)
 
-      val connector    = mock[NDRCConnector]
-      val response     = ClientClaimSuccessResponse("1", None, Some(NDRCFileTransferResult("caseId", LocalDateTime.now)))
+      val connector = mock[NDRCConnector]
+      val response  = ClientClaimSuccessResponse("1", None, Some(NDRCFileTransferResult("caseId", LocalDateTime.now)))
       when(connector.submitClaim(any(), any())(any())).thenReturn(Future.successful(response))
 
       val service = new ClaimService(connector)(ExecutionContext.global)
@@ -61,8 +61,8 @@ class ClaimServiceSpec extends SpecBase with MustMatchers with ScalaCheckPropert
       implicit val request: Request[_] = FakeRequest().withSession(SessionKeys.authToken -> "Bearer XYZ")
       val dataRequest                  = DataRequest(request, "12", testUserAnswers)
 
-      val connector    = mock[NDRCConnector]
-      val response     = ClientClaimSuccessResponse("1", Some(ApiError("409", Some("Aa"))), None)
+      val connector = mock[NDRCConnector]
+      val response  = ClientClaimSuccessResponse("1", Some(ApiError("409", Some("Aa"))), None)
       when(connector.submitClaim(any(), any())(any())).thenReturn(Future.successful(response))
 
       val service = new ClaimService(connector)(ExecutionContext.global)
@@ -79,8 +79,8 @@ class ClaimServiceSpec extends SpecBase with MustMatchers with ScalaCheckPropert
       implicit val request: Request[_] = FakeRequest().withSession(SessionKeys.authToken -> "Bearer XYZ")
       val dataRequest                  = DataRequest(request, "12", testUserAnswers)
 
-      val connector    = mock[NDRCConnector]
-      val response     = ClientClaimSuccessResponse("1", Some(ApiError("500", Some("Aa"))), None)
+      val connector = mock[NDRCConnector]
+      val response  = ClientClaimSuccessResponse("1", Some(ApiError("500", Some("Aa"))), None)
       when(connector.submitClaim(any(), any())(any())).thenReturn(Future.successful(response))
       val message = response.error.map(_.errorCode).map(_ + " ").getOrElse("") +
         response.error.map(_.errorMessage).getOrElse("")
@@ -99,8 +99,8 @@ class ClaimServiceSpec extends SpecBase with MustMatchers with ScalaCheckPropert
       implicit val request: Request[_] = FakeRequest().withSession(SessionKeys.authToken -> "Bearer XYZ")
       val dataRequest                  = DataRequest(request, "12", testUserAnswers)
 
-      val connector    = mock[NDRCConnector]
-      val response     = ClientClaimSuccessResponse("1", None, Some(NDRCFileTransferResult("caseId", LocalDateTime.now)))
+      val connector = mock[NDRCConnector]
+      val response  = ClientClaimSuccessResponse("1", None, Some(NDRCFileTransferResult("caseId", LocalDateTime.now)))
       when(connector.submitAmendClaim(any(), any())(any())).thenReturn(Future.successful(response))
 
       val service = new ClaimService(connector)(ExecutionContext.global)
@@ -113,10 +113,10 @@ class ClaimServiceSpec extends SpecBase with MustMatchers with ScalaCheckPropert
 
       implicit val hc: HeaderCarrier   = HeaderCarrier()
       implicit val request: Request[_] = FakeRequest().withSession(SessionKeys.authToken -> "Bearer XYZ")
-      val dataRequest      = DataRequest(request, "12", testUserAnswers)
+      val dataRequest                  = DataRequest(request, "12", testUserAnswers)
 
-      val connector    = mock[NDRCConnector]
-      val response     = ClientClaimSuccessResponse("1", Some(ApiError("500", Some("Aa"))), None)
+      val connector = mock[NDRCConnector]
+      val response  = ClientClaimSuccessResponse("1", Some(ApiError("500", Some("Aa"))), None)
       when(connector.submitAmendClaim(any(), any())(any())).thenReturn(Future.successful(response))
       val message = response.error.map(_.errorCode).map(_ + " ").getOrElse("") +
         response.error.map(_.errorMessage).getOrElse("")


### PR DESCRIPTION
Base the correlation ID off the current x-request-id if it exists (else generate a new one)