### PR TITLE
NF-570 - fix for Navigator generated back links on amend journey

### DIFF
--- a/app/assets/stylesheets/components/back-link.scss
+++ b/app/assets/stylesheets/components/back-link.scss
@@ -5,3 +5,11 @@
 .js-enabled .app-back-link {
   display: inline-block;
 }
+
+.nav-back-link {
+  display: none;
+}
+
+.js-enabled .nav-back-link {
+  display: inline-block;
+}

--- a/app/views/layouts/GovukLayoutWrapper.scala.html
+++ b/app/views/layouts/GovukLayoutWrapper.scala.html
@@ -91,7 +91,7 @@ refresh: Int = 0)(contentBlock: Html)(implicit request: Request[_], messages: Me
     @backLinkNav.flatMap(_.maybeCall.map( call =>
         govukBackLink(BackLink(
             attributes = Map("id"->"back-link"),
-            classes = "govuk-!-display-none-print app-back-link",
+            classes = "govuk-!-display-none-print nav-back-link",
             href = call.url,
             content = Text(messages("site.back"))
         ))


### PR DESCRIPTION
This is a temporary fix to prevent the existing javascript back-link behaviour (which is still required for create journey) interfering with the navigator generated back links for amend journey.

The change is to give the navigator back links a new css class name.   The existing class (app-back-link) will be removed as part of NF-552)