### PR TITLE
NF-722 - IE 11 print bug

### DIFF
--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -8,7 +8,7 @@ from the view and the page (url/page number, etc.)
 */
 @media all {
   .ndrc-\21-display-only-print {
-    display: none
+    display: none;
   }
 }
 
@@ -17,14 +17,14 @@ from the view and the page (url/page number, etc.)
     margin: 10px
   }
   .govuk-section-break {
-    page-break-inside: avoid
+    page-break-inside: avoid;
   }
   .hmrc-sign-out-nav__link {
     display: none;
   }
   .ndrc-\21-display-only-print {
     display: block; // For browsers that don't support contents
-    display: contents
+    display: contents;
   }
   footer {
     display: none;

--- a/app/assets/stylesheets/media.scss
+++ b/app/assets/stylesheets/media.scss
@@ -7,15 +7,29 @@ from the view and the page (url/page number, etc.)
 ====================================
 */
 @media all {
-  .ndrc-\21-display-only-print { display: none}
+  .ndrc-\21-display-only-print {
+    display: none
+  }
 }
+
 @media print {
-  @page { margin: 10px }
-  .govuk-section-break { page-break-inside : avoid }
-  .hmrc-sign-out-nav__link { display: none; }
-  .ndrc-\21-display-only-print{ display: contents}
-  footer { display: none; }
-  @-moz-document url-prefix() {
-    .govuk-summary-list__key { width: 40%; }
+  @page {
+    margin: 10px
+  }
+  .govuk-section-break {
+    page-break-inside: avoid
+  }
+  .hmrc-sign-out-nav__link {
+    display: none;
+  }
+  .ndrc-\21-display-only-print {
+    display: block; // For browsers that don't support contents
+    display: contents
+  }
+  footer {
+    display: none;
+  }
+  .govuk-summary-list__key {
+    width: 40%;
   }
 }


### PR DESCRIPTION
Main change is to add `display: block` as a default for `ndrc-\21-display-only-print` as IE11 does not support `display: contents` (which was causing the section to remain `display: none` (i.e. hidden))