### PR TITLE
BAU -  fix Welsh language selection

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -20,7 +20,7 @@ import com.google.inject.{ImplementedBy, Inject}
 import controllers.routes
 import javax.inject.Singleton
 import play.api.Configuration
-import play.api.i18n.Lang
+import play.api.i18n.Langs
 import play.api.mvc.Call
 
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
@@ -83,8 +83,6 @@ trait FrontendAppConfig {
   val eoriIntegration: FrontendAppConfig.EoriIntegration
   val emails: FrontendAppConfig.Emails
 
-  def languageMap: Map[String, Lang]
-
   val routeToSwitchLanguage: String => Call
   val locationCanonicalList: String
   val feedbackSurvey: String
@@ -99,7 +97,7 @@ trait FrontendAppConfig {
 }
 
 @Singleton
-class FrontendAppConfigImpl @Inject() (configuration: Configuration) extends FrontendAppConfig {
+class FrontendAppConfigImpl @Inject() (configuration: Configuration, langs: Langs) extends FrontendAppConfig {
 
   override val appName: String              = configuration.get[String]("appName")
   override val contactHost                  = configuration.get[String]("contact-frontend.host")
@@ -145,8 +143,7 @@ class FrontendAppConfigImpl @Inject() (configuration: Configuration) extends Fro
   override val loginUrl: String         = configuration.get[String]("urls.login")
   override val loginContinueUrl: String = configuration.get[String]("urls.loginContinue")
 
-  override val languageTranslationEnabled: Boolean =
-    configuration.get[Boolean]("microservice.services.features.welsh-translation")
+  override val languageTranslationEnabled: Boolean = langs.availables.exists(_.language == "cy")
 
   override val signOutUrl: String       = configuration.get[String]("urls.logout")
   private lazy val feedbackHost: String = configuration.get[String]("feedback-frontend.host")
@@ -185,8 +182,6 @@ class FrontendAppConfigImpl @Inject() (configuration: Configuration) extends Fro
     configuration.get[Service]("microservice.services.upscan-initiate").baseUrl
 
   lazy val locationCanonicalList: String = loadConfig("location.canonical.list")
-
-  override def languageMap: Map[String, Lang] = Map("english" -> Lang("en"), "cymraeg" -> Lang("cy"))
 
   override val routeToSwitchLanguage: String => Call =
     (lang: String) => routes.LanguageSwitchController.switchToLanguage(lang)

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -20,7 +20,7 @@ import com.google.inject.{ImplementedBy, Inject}
 import controllers.routes
 import javax.inject.Singleton
 import play.api.Configuration
-import play.api.i18n.Langs
+import play.api.i18n.{Lang, Langs}
 import play.api.mvc.Call
 
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
@@ -82,6 +82,8 @@ trait FrontendAppConfig {
 
   val eoriIntegration: FrontendAppConfig.EoriIntegration
   val emails: FrontendAppConfig.Emails
+
+  def languageMap: Map[String, Lang]
 
   val routeToSwitchLanguage: String => Call
   val locationCanonicalList: String
@@ -185,6 +187,10 @@ class FrontendAppConfigImpl @Inject() (configuration: Configuration, langs: Lang
 
   override val routeToSwitchLanguage: String => Call =
     (lang: String) => routes.LanguageSwitchController.switchToLanguage(lang)
+
+  override def languageMap: Map[String, Lang] = if (languageTranslationEnabled)
+    Map("english"    -> Lang("en"), "cymraeg" -> Lang("cy"))
+  else Map("english" -> Lang("en"))
 
   private def loadConfig(key: String): String =
     configuration.getOptional[String](key).getOrElse(throw new Exception(s"Missing configuration key: $key"))

--- a/app/controllers/LanguageSwitchController.scala
+++ b/app/controllers/LanguageSwitchController.scala
@@ -18,35 +18,24 @@ package controllers
 
 import com.google.inject.Inject
 import config.FrontendAppConfig
-import play.api.Configuration
-import play.api.i18n.{I18nSupport, Lang, MessagesApi}
+import javax.inject.Singleton
+import play.api.i18n.Lang
 import play.api.mvc._
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import uk.gov.hmrc.play.language.{LanguageController, LanguageUtils}
 
+@Singleton
 class LanguageSwitchController @Inject() (
-  configuration: Configuration,
   appConfig: FrontendAppConfig,
-  override implicit val messagesApi: MessagesApi,
-  val controllerComponents: MessagesControllerComponents
-) extends FrontendBaseController with I18nSupport {
+  languageUtils: LanguageUtils,
+  cc: ControllerComponents
+) extends LanguageController(languageUtils, cc) {
 
-  private def fallbackURL: String = routes.IndexController.onPageLoad().url
+  override def fallbackURL: String =
+    routes.IndexController.onPageLoad().url
 
-  private def languageMap: Map[String, Lang] = appConfig.languageMap
-
-  def switchToLanguage(language: String): Action[AnyContent] = Action {
-    implicit request =>
-      val enabled = isWelshEnabled
-      val lang =
-        if (enabled)
-          languageMap.getOrElse(language, Lang.defaultLang)
-        else
-          Lang("en")
-      val redirectURL = request.headers.get(REFERER).getOrElse(fallbackURL)
-      Redirect(redirectURL).withLang(Lang.apply(lang.code))
-  }
-
-  private def isWelshEnabled: Boolean =
-    configuration.getOptional[Boolean]("microservice.services.features.welsh-translation").getOrElse(true)
+  override protected def languageMap: Map[String, Lang] =
+    if (appConfig.languageTranslationEnabled)
+      Map("english"    -> Lang("en"), "cymraeg" -> Lang("cy"))
+    else Map("english" -> Lang("en"))
 
 }

--- a/app/controllers/LanguageSwitchController.scala
+++ b/app/controllers/LanguageSwitchController.scala
@@ -33,9 +33,6 @@ class LanguageSwitchController @Inject() (
   override def fallbackURL: String =
     routes.IndexController.onPageLoad().url
 
-  override protected def languageMap: Map[String, Lang] =
-    if (appConfig.languageTranslationEnabled)
-      Map("english"    -> Lang("en"), "cymraeg" -> Lang("cy"))
-    else Map("english" -> Lang("en"))
+  override protected def languageMap: Map[String, Lang] = appConfig.languageMap
 
 }

--- a/app/models/addresslookup/AddressLookupRequest.scala
+++ b/app/models/addresslookup/AddressLookupRequest.scala
@@ -46,8 +46,28 @@ object AddressLookupRequest {
     editPageHeadingKey: String,
     confirmationHeadingKey: String
   )(implicit messagesApi: MessagesApi, config: FrontendAppConfig): AddressLookupRequest = {
-    val eng: Messages = MessagesImpl(Lang("en"), messagesApi)
-    val cy: Messages  = MessagesImpl(Lang("cy"), messagesApi)
+    val englishMessages: Messages = MessagesImpl(Lang("en"), messagesApi)
+    val welshMessages: Messages  = MessagesImpl(Lang("cy"), messagesApi)
+
+    def labels(messages: Messages) = AddressLookupRequest.Labels.Language(
+      AppLevelLabels(navTitle = Some(messages("site.service_name"))),
+      SelectPageLabels(
+        title = Some(messages("address.label.select.title")),
+        heading = Some(messages("address.label.select.title"))
+      ),
+      LookupPageLabels(
+        title = Some(messages(lookupPageHeadingKey)),
+        heading = Some(messages(lookupPageHeadingKey)),
+        afterHeadingText = Some(messages(hintKey))
+      ),
+      ConfirmPageLabels(title = Some(messages(confirmationHeadingKey)), heading = Some(messages(confirmationHeadingKey))),
+      EditPageLabels(
+        postcodeLabel = Some(messages("address.label.edit.postcode")),
+        title = Some(messages(editPageHeadingKey)),
+        heading = Some(messages(editPageHeadingKey))
+      )
+    )
+
     new AddressLookupRequest(
       2,
       Options(
@@ -66,33 +86,8 @@ object AddressLookupRequest {
         )
       ),
       Labels(
-        en =
-          AddressLookupRequest.Labels.Language(
-            AppLevelLabels(navTitle = Some(eng("site.service_name"))),
-            SelectPageLabels(
-              title = Some(eng("address.label.select.title")),
-              heading = Some(eng("address.label.select.title"))
-            ),
-            LookupPageLabels(
-              title = Some(eng(lookupPageHeadingKey)),
-              heading = Some(eng(lookupPageHeadingKey)),
-              afterHeadingText = Some(eng(hintKey))
-            ),
-            ConfirmPageLabels(title = Some(eng(confirmationHeadingKey)), heading = Some(eng(confirmationHeadingKey))),
-            EditPageLabels(
-              postcodeLabel = Some(eng("address.label.edit.postcode")),
-              title = Some(eng(editPageHeadingKey)),
-              heading = Some(eng(editPageHeadingKey))
-            )
-          ),
-        cy =
-          AddressLookupRequest.Labels.Language(
-            AppLevelLabels(navTitle = Some(cy("site.service_name"))),
-            SelectPageLabels(),
-            LookupPageLabels(heading = Some(eng(lookupPageHeadingKey))),
-            ConfirmPageLabels(),
-            EditPageLabels()
-          )
+        en = labels(englishMessages),
+        cy = labels(if(config.languageTranslationEnabled)welshMessages else englishMessages)
       )
     )
   }

--- a/app/models/addresslookup/AddressLookupRequest.scala
+++ b/app/models/addresslookup/AddressLookupRequest.scala
@@ -47,7 +47,7 @@ object AddressLookupRequest {
     confirmationHeadingKey: String
   )(implicit messagesApi: MessagesApi, config: FrontendAppConfig): AddressLookupRequest = {
     val englishMessages: Messages = MessagesImpl(Lang("en"), messagesApi)
-    val welshMessages: Messages  = MessagesImpl(Lang("cy"), messagesApi)
+    val welshMessages: Messages   = MessagesImpl(Lang("cy"), messagesApi)
 
     def labels(messages: Messages) = AddressLookupRequest.Labels.Language(
       AppLevelLabels(navTitle = Some(messages("site.service_name"))),
@@ -60,7 +60,10 @@ object AddressLookupRequest {
         heading = Some(messages(lookupPageHeadingKey)),
         afterHeadingText = Some(messages(hintKey))
       ),
-      ConfirmPageLabels(title = Some(messages(confirmationHeadingKey)), heading = Some(messages(confirmationHeadingKey))),
+      ConfirmPageLabels(
+        title = Some(messages(confirmationHeadingKey)),
+        heading = Some(messages(confirmationHeadingKey))
+      ),
       EditPageLabels(
         postcodeLabel = Some(messages("address.label.edit.postcode")),
         title = Some(messages(editPageHeadingKey)),
@@ -87,7 +90,7 @@ object AddressLookupRequest {
       ),
       Labels(
         en = labels(englishMessages),
-        cy = labels(if(config.languageTranslationEnabled)welshMessages else englishMessages)
+        cy = labels(if (config.languageTranslationEnabled) welshMessages else englishMessages)
       )
     )
   }

--- a/app/views/layouts/GovukLayoutWrapper.scala.html
+++ b/app/views/layouts/GovukLayoutWrapper.scala.html
@@ -95,7 +95,7 @@ refresh: Int = 0)(contentBlock: Html)(implicit request: Request[_], messages: Me
 
     @if(appConfig.languageTranslationEnabled) {
         @languageSelection(
-            appConfig.languageMap,
+            Map("english" -> Lang("en"), "cymraeg" -> Lang("cy")),
             appConfig.routeToSwitchLanguage
         )
     }

--- a/app/views/layouts/GovukLayoutWrapper.scala.html
+++ b/app/views/layouts/GovukLayoutWrapper.scala.html
@@ -95,7 +95,7 @@ refresh: Int = 0)(contentBlock: Html)(implicit request: Request[_], messages: Me
 
     @if(appConfig.languageTranslationEnabled) {
         @languageSelection(
-            Map("english" -> Lang("en"), "cymraeg" -> Lang("cy")),
+            appConfig.languageMap,
             appConfig.routeToSwitchLanguage
         )
     }

--- a/app/views/layouts/GovukLayoutWrapper.scala.html
+++ b/app/views/layouts/GovukLayoutWrapper.scala.html
@@ -93,10 +93,12 @@ refresh: Int = 0)(contentBlock: Html)(implicit request: Request[_], messages: Me
         @phaseBanner("beta")
     }
 
-    @languageSelection(
-        appConfig.languageMap,
-        appConfig.routeToSwitchLanguage
-    )
+    @if(appConfig.languageTranslationEnabled) {
+        @languageSelection(
+            appConfig.languageMap,
+            appConfig.routeToSwitchLanguage
+        )
+    }
 
     @{backLinkNav.flatMap(_.maybeCall) match {
         case Some(call) => govukBackLink(BackLink(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,10 +61,6 @@ microservice {
         port = 8500
       }
 
-      features {
-        welsh-translation: false
-      }
-
       national-duty-repayment-center {
         protocol = "http"
         host = localhost

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -40,7 +40,8 @@ play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 play.modules.enabled += "config.Module"
 play.modules.enabled+="com.kenshoo.play.metrics.PlayModule"
 
-play.i18n.langs = ["en", "cy"]
+# Change this to ["en", "cy"] when Welsh translations available
+play.i18n.langs = ["en"]
 
 microservice {
   metrics {

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -24,6 +24,7 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.{reset, spy, when}
 import org.scalatest.BeforeAndAfterEach
 import play.api.Configuration
+import play.api.i18n.Langs
 import play.api.mvc.{BodyParsers, Result, Results}
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
@@ -38,8 +39,9 @@ class AuthActionSpec extends SpecBase with BeforeAndAfterEach {
   val authConnector: AuthConnector = mock[AuthConnector]
 
   val realConfig                = injector.instanceOf[Configuration]
+  val realLangs                 = injector.instanceOf[Langs]
   val mockConfig: Configuration = spy(realConfig)
-  def appConfig                 = new FrontendAppConfigImpl(mockConfig)
+  def appConfig                 = new FrontendAppConfigImpl(mockConfig, realLangs)
 
   val enrolmentsWithoutEORI: Enrolments = Enrolments(
     Set(Enrolment(key = "IR-SA", identifiers = Seq(EnrolmentIdentifier("UTR", "123")), state = "Activated"))

--- a/test/models/addresslookup/AddressLookupRequestSpec.scala
+++ b/test/models/addresslookup/AddressLookupRequestSpec.scala
@@ -89,12 +89,21 @@ class AddressLookupRequestSpec extends WordSpec with MustMatchers with MockitoSu
           )
         ),
       cy =
+        // Note - the strings below will need updating when Welsh translations are available
         AddressLookupRequest.Labels.Language(
-          AppLevelLabels(navTitle = Some("TODO Welsh service name")),
-          SelectPageLabels(),
-          LookupPageLabels(heading = Some("What is your address?")),
-          ConfirmPageLabels(),
-          EditPageLabels()
+          AppLevelLabels(navTitle = Some("Apply for repayment of import duty and import VAT")),
+          SelectPageLabels(title = Some("Select an address"), heading = Some("Select an address")),
+          LookupPageLabels(
+            title = Some("What is your address?"),
+            heading = Some("What is your address?"),
+            afterHeadingText = Some("We will use this to send letters about this application.")
+          ),
+          ConfirmPageLabels(title = Some("Confirm your address"), heading = Some("Confirm your address")),
+          EditPageLabels(
+            title = Some("Enter your address"),
+            heading = Some("Enter your address"),
+            postcodeLabel = Some("Postcode")
+          )
         )
     )
   )


### PR DESCRIPTION
Currently the service displays message keys rather than messages if user switches to Welsh in ALF and returns to service.

Proposed changes
- remove language switcher from UI if service does not support Welsh
- ensure that English messages are used for Welsh user (e.g. returning from ALF)
- simplify the config to enable Welsh - all in single `play.i18n.langs` property now (which is required anyway)
- ensure that all ALF labels are sent as part of initialisation in English and Welsh (with Welsh defaulting to English if Welsh not enabled)